### PR TITLE
workaround fix to teams/channnels update when receiving associate events

### DIFF
--- a/mattermost_bot/mattermost.py
+++ b/mattermost_bot/mattermost.py
@@ -208,7 +208,7 @@ class MattermostClient(object):
                     else ssl.CERT_NONE
             })
 
-    def messages(self, ignore_own_msg=False, filter_action=None):
+    def messages(self, ignore_own_msg=False, filter_actions=[]):
         if not self.connect_websocket():
             return
         while True:
@@ -221,15 +221,21 @@ class MattermostClient(object):
             if data:
                 try:
                     post = json.loads(data)
-                    if filter_action and post.get('event') != filter_action:
+                    event_action = post.get('event')
+                    if event_action not in filter_actions:
                         continue
 
-                    if post.get('data', {}).get('post'):
-                        dp = json.loads(post['data']['post'])
-                        if ignore_own_msg is True and dp.get("user_id"):
-                            if self.user["id"] == dp["user_id"]:
-                                continue
-                    yield post
+                    if event_action == 'posted':
+                        if post.get('data', {}).get('post'):
+                            dp = json.loads(post['data']['post'])
+                            if ignore_own_msg is True and dp.get("user_id"):
+                                if self.user["id"] == dp["user_id"]:
+                                    continue
+                        yield post
+                    elif event_action in ['added_to_team', 'leave_team',
+                                          'user_added', 'user_removed']:
+                        self.api.load_initial_data()  # reload teams & channels
+
                 except ValueError:
                     pass
 

--- a/mattermost_bot/plugins/channel.py
+++ b/mattermost_bot/plugins/channel.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+import re
+
+from mattermost_bot.bot import respond_to
+
+
+@respond_to('(.*) added to the channel by (.*)', re.IGNORECASE)
+def added_to_channel(message, myname, channel_admin):
+    message.reply('Hi, %s. I am %s. Glad to join this channel :) ' % (channel_admin, myname))
+
+added_to_channel.__doc__ = "Response when added to a channel"


### PR DESCRIPTION
Without dealing with added_to_team, leave_team, user_added, user_removed, the teams and channels in user state will be inacccurate after event happends. This fix enforces user initial data to be reloaded when receiving these four events.